### PR TITLE
Role para Hardening SSH

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/Documents/github/iac-role-basica/.venv/bin/python3"
+}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,3 +14,42 @@
       - name: gomex
         username: gomex
         ssh_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYc9rlj0wKka5t31T4EiTanSmXpswDg00dYmuwdvEW3bAovcdzt6p3kgFxpPaZj7X6oFfvSCXpoL+/yjngujEW9CGbqfdVyvCodIuIaGuoUsxo7dtMCLzqZtGGe1m6xoTyNqZQzv68nF1fZ/ku7YNK9HGKKcjNJVvs6ocqK5Jbdb6IGRF64kP4hx8IX5n8CU8APn5esrh6BNhViKHWYIGDYoFkd54Z4CeD156BYl1OhWbla6u1vOntpj1uw3Lp+haAWbXSJMCpztsYPeynrQ14GUbHPRAsO4IILD5CtZWsp16VnEIAhsIqrnzp1BGTduwbX5VVzY3K7JdFNEWThFhd"
+    ssh_hard:
+      - option: permitrootlogin
+        key: no
+      - option: PubkeyAuthentication
+        key: yes
+      - option: PasswordAuthentication
+        key: no
+      - option: PermitEmptyPasswords
+        key: no
+      - option: logingracetime
+        key: 20
+      - option: MaxAuthTries
+        key: 3
+      - option: HostbasedAuthentication
+        key: no
+      - option: ChallengeResponseAuthentication
+        key: no
+      - option: KerberosAuthentication
+        key: no
+      - option: GSSAPIAuthentication
+        key: no
+      - option: X11Forwarding
+        key: no
+      - option: PermitUserEnvironment
+        key: no
+      - option: AllowAgentForwarding
+        key: no
+      - option: AllowTcpForwarding
+        key: no
+      - option: PermitTunnel
+        key: no
+      - option: Banner
+        key: none
+      - option: VersionAddendum
+        key: none
+      - option: Protocol
+        key: 2
+      - option: IgnoreRhosts
+        key: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,3 +32,12 @@
     key: "{{ item.ssh_key }}"
   with_items: "{{ dokku_users }}"
   when: dokku_users is defined
+
+- name: Hardening SSH
+    ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: "{{ item.option }}"
+    line: "{{ item.option }}" "{{ item.key }}"
+   with_itens: "{{ ssh_hard }}"
+   when: ssh_hard is defined
+         


### PR DESCRIPTION
fazer o hardening do SSH com base nos seguintes parâmetros:

# Não permitir login de root
permitrootlogin no

# Login APENAS com chave publica
PubkeyAuthentication yes
PasswordAuthentication no
PermitEmptyPasswords no

# Limitar o tempo de autenticação (LoginGraceTime)
logingracetime 120

# Limitar em 3 o número de tentativas
MaxAuthTries 3

# Desabilitar outros métodos de autenticação ( ChallengeResponseAuthentication no, KerberosAuthentication no, GSSAPIAuthentication no)
HostbasedAuthentication no
ChallengeResponseAuthentication no
KerberosAuthentication no
GSSAPIAuthentication no

# Desabilitar o X11Forwarding
X11Forwarding no

# Desabilitar PermitUserEnvironment
PermitUserEnvironment no

# Desabilitar AllowAgentForwarding
AllowAgentForwarding no

# Desabilitar AllowTcpForwarding
AllowTcpForwarding

# Desabilitar o PermitTunnel
PermitTunnel

# Desabilitar o Banner (DebianBanner?)
Banner none
VersionAddendum none

# Forçar o protocolo 2 (Protocol 2)
Protocol 2

# Desabilitar o rhosts
IgnoreRhosts yes